### PR TITLE
feat: 재사용 소수점 반영

### DIFF
--- a/src/main/java/org/mapledpmlab/old/farm/BuffFarm.java
+++ b/src/main/java/org/mapledpmlab/old/farm/BuffFarm.java
@@ -56,7 +56,7 @@ public class BuffFarm extends Farm {
         this.addIgnoreDefenseList(5L);   // 라피스
         this.addIgnoreDefenseList(5L);   // 쁘띠매그너스
         this.addIgnoreDefenseList(6L);   // 양철나무꾼
-        this.addReuse(4L);          // 쁘띠은월
+        this.addReuse(4.0);          // 쁘띠은월
         this.addAtt(5L);            // 쁘띠루미너스(어둠)
         this.addMagic(5L);
         this.addAtt(5L);            // 미르

--- a/src/main/java/org/mapledpmlab/old/farm/DemonAvengerFarm.java
+++ b/src/main/java/org/mapledpmlab/old/farm/DemonAvengerFarm.java
@@ -53,7 +53,7 @@ public class DemonAvengerFarm extends Farm {
         this.addIgnoreDefenseList(5L);   // 라피스
         this.addIgnoreDefenseList(5L);   // 쁘띠매그너스
         this.addIgnoreDefenseList(6L);   // 양철나무꾼
-        this.addReuse(4L);          // 쁘띠은월
+        this.addReuse(4.0);          // 쁘띠은월
         this.addAtt(3L);            // 무공의분신
         this.addAtt(5L);            // 쁘띠루미너스(어둠)
         this.addMagic(5L);

--- a/src/main/java/org/mapledpmlab/old/farm/FinalAttackFarm.java
+++ b/src/main/java/org/mapledpmlab/old/farm/FinalAttackFarm.java
@@ -60,7 +60,7 @@ public class FinalAttackFarm extends Farm {
         this.addIgnoreDefenseList(5L);   // 라피스
         this.addIgnoreDefenseList(5L);   // 쁘띠매그너스
         this.addIgnoreDefenseList(6L);   // 양철나무꾼
-        this.addReuse(4L);          // 쁘띠은월
+        this.addReuse(4.0);          // 쁘띠은월
         this.addAtt(5L);            // 쁘띠루미너스(어둠)
         this.addMagic(5L);
         this.addAtt(5L);            // 미르

--- a/src/main/java/org/mapledpmlab/old/farm/FinalAttackReuseFarm.java
+++ b/src/main/java/org/mapledpmlab/old/farm/FinalAttackReuseFarm.java
@@ -56,8 +56,8 @@ public class FinalAttackReuseFarm extends Farm {
         this.addIgnoreDefenseList(5L);   // 라피스
         this.addIgnoreDefenseList(5L);   // 쁘띠매그너스
         this.addIgnoreDefenseList(6L);   // 양철나무꾼
-        this.addReuse(4L);          // 쁘띠은월
-        this.addReuse(2L);          // 큰운영자의벌룬
+        this.addReuse(4.0);          // 쁘띠은월
+        this.addReuse(2.0);          // 큰운영자의벌룬
         this.addAtt(5L);            // 쁘띠루미너스(어둠)
         this.addMagic(5L);
         this.addAtt(5L);            // 미르

--- a/src/main/java/org/mapledpmlab/old/farm/NormalFarm.java
+++ b/src/main/java/org/mapledpmlab/old/farm/NormalFarm.java
@@ -68,7 +68,7 @@ public class NormalFarm extends Farm {
         this.addIgnoreDefenseList(5L);   // 라피스
         this.addIgnoreDefenseList(5L);   // 쁘띠매그너스
         this.addIgnoreDefenseList(6L);   // 양철나무꾼
-        this.addReuse(4L);          // 쁘띠은월
+        this.addReuse(4.0);          // 쁘띠은월
         this.addAtt(5L);            // 쁘띠루미너스(어둠)
         this.addMagic(5L);
         this.addAtt(5L);            // 미르

--- a/src/main/java/org/mapledpmlab/old/farm/ReuseFarm.java
+++ b/src/main/java/org/mapledpmlab/old/farm/ReuseFarm.java
@@ -64,8 +64,8 @@ public class ReuseFarm extends Farm {
         this.addIgnoreDefenseList(5L);   // 라피스
         this.addIgnoreDefenseList(5L);   // 쁘띠매그너스
         this.addIgnoreDefenseList(6L);   // 양철나무꾼
-        this.addReuse(4L);          // 쁘띠은월
-        this.addReuse(2L);          // 큰운영자의벌룬
+        this.addReuse(4.0);          // 쁘띠은월
+        this.addReuse(2.0);          // 큰운영자의벌룬
         this.addAtt(5L);            // 쁘띠루미너스(어둠)
         this.addMagic(5L);
         this.addAtt(5L);            // 미르

--- a/src/main/java/org/mapledpmlab/type/ability/BossAbnormalReuse.java
+++ b/src/main/java/org/mapledpmlab/type/ability/BossAbnormalReuse.java
@@ -10,6 +10,6 @@ public class BossAbnormalReuse extends Ability {
         );
         this.addBossDamage(20L);
         this.addStatXDamage(8L);
-        this.addReuse(10L);
+        this.addReuse(10.0);
     }
 }

--- a/src/main/java/org/mapledpmlab/type/ability/BossBuffReuse.java
+++ b/src/main/java/org/mapledpmlab/type/ability/BossBuffReuse.java
@@ -10,6 +10,6 @@ public class BossBuffReuse extends Ability {
         );
         this.addBossDamage(20L);
         this.addPlusBuffDuration(38L);
-        this.addReuse(10L);
+        this.addReuse(10.0);
     }
 }

--- a/src/main/java/org/mapledpmlab/type/ability/BossCriticalReuse.java
+++ b/src/main/java/org/mapledpmlab/type/ability/BossCriticalReuse.java
@@ -10,6 +10,6 @@ public class BossCriticalReuse extends Ability {
         );
         this.addBossDamage(20L);
         this.addCriticalP(20.0);
-        this.addReuse(10L);
+        this.addReuse(10.0);
     }
 }

--- a/src/main/java/org/mapledpmlab/type/ability/PassiveBossReuse.java
+++ b/src/main/java/org/mapledpmlab/type/ability/PassiveBossReuse.java
@@ -9,6 +9,6 @@ public class PassiveBossReuse extends Ability {
                 "\n3.재사용 대기시간 미적용 10%\n"
         );
         this.addBossDamage(10L);
-        this.addReuse(10L);
+        this.addReuse(10.0);
     }
 }

--- a/src/main/java/org/mapledpmlab/type/ability/ReuseBossAbnormal.java
+++ b/src/main/java/org/mapledpmlab/type/ability/ReuseBossAbnormal.java
@@ -8,7 +8,7 @@ public class ReuseBossAbnormal extends Ability {
                 "\n2.보스 공격 시 데미지 10%" +
                 "\n3.상태 이상에 걸린 대상 공격 시 데미지 8%\n"
         );
-        this.addReuse(20L);
+        this.addReuse(20.0);
         this.addBossDamage(10L);
         this.addStatXDamage(8L);
     }

--- a/src/main/java/org/mapledpmlab/type/ability/ReuseBossCritical.java
+++ b/src/main/java/org/mapledpmlab/type/ability/ReuseBossCritical.java
@@ -8,7 +8,7 @@ public class ReuseBossCritical extends Ability {
                 "\n2.보스 공격 시 데미지 10%" +
                 "\n3.크리티컬 확률 20%\n"
         );
-        this.addReuse(20L);
+        this.addReuse(20.0);
         this.addBossDamage(10L);
         this.addCriticalP(20.0);
     }

--- a/src/main/java/org/mapledpmlab/type/artifact/Artifact.java
+++ b/src/main/java/org/mapledpmlab/type/artifact/Artifact.java
@@ -12,7 +12,7 @@ public class Artifact extends Common {
                 "\n4.보스 공격 시 데미지 15%" +
                 "\n5.몬스터 방어율 무시 20%" +
                 "\n6.버프 지속시간 20%" +
-                "\n7.재사용 대기시간 미적용 7%" +
+                "\n7.재사용 대기시간 미적용 7.5%" +
                 "\n8.크리티컬 확률 20%" +
                 "\n9.크리티컬 데미지 4%" +
                 "\n10.파이널 어택류 스킬의 데미지 30%" +
@@ -29,7 +29,7 @@ public class Artifact extends Common {
         this.addDamage(15L);
         this.addIgnoreDefenseList(20L);
         this.addPlusBuffDuration(20L);
-        this.addReuse(7L);
+        this.addReuse(7.5);
         this.addCriticalP(20.0);
         this.addCriticalDamage(4.0);
         this.addDamage(15L);

--- a/src/main/java/org/mapledpmlab/type/artifact/DemonAvengerArtifact.java
+++ b/src/main/java/org/mapledpmlab/type/artifact/DemonAvengerArtifact.java
@@ -26,7 +26,7 @@ public class DemonAvengerArtifact extends Farm {
         this.addDamage(15L);
         this.addIgnoreDefenseList(20L);
         this.addPlusBuffDuration(20L);
-        this.addReuse(7L);
+        this.addReuse(7.0);
         this.addCriticalP(20.0);
         this.addCriticalDamage(4.0);
         this.addDamage(15L);

--- a/src/main/java/org/mapledpmlab/type/etc/Common.java
+++ b/src/main/java/org/mapledpmlab/type/etc/Common.java
@@ -36,7 +36,7 @@ public class Common {
     private Long perXSubStat = 0L;
     private Long plusBuffDuration = 0L;
     private Long property = 0L;
-    private Long reuse = 0L;
+    private Double reuse = 0.0;
     private Long statXDamage = 0L;
     private Double statXFinalDamage = 1.0;
     private List<Long> statXIgnoreDefenseList = new ArrayList<>();
@@ -158,7 +158,7 @@ public class Common {
         this.property += property;
     }
 
-    public void addReuse(Long reuse) {
+    public void addReuse(Double reuse) {
         this.reuse += reuse;
     }
 
@@ -333,7 +333,7 @@ public class Common {
         if (getProperty() != 0) {
             str += "\n속성 내성 무시 : " + getProperty();
         }
-        if (getReuse() != 0) {
+        if (getReuse() != 0.0) {
             str += "\n재사용 : " + getReuse();
         }
         if (getStatXFinalDamage() != 1) {


### PR DESCRIPTION
아티팩트 재사용이 7%인 이유가 재사용을 정수로 선언한 걸 재정의하기 어려워서라는 내용을 봤습니다.
생각보다 간단한 내용인 거 같아서 한 번 수정해서 풀 리퀘스트 올립니다.

주요 변경 사항:
1. Common.java: reuse 필드 타입을 Long에서 Double로 변경
2. addReuse 메서드: Long 파라미터를 Double로 변경

제가 개발 지식이 부족한 입장이라 잘 확인해보시길 바라며, 모쪼록 도움이 되셨으면 좋겠네요.