### PR TITLE
솔루나 슬래시 쿨타임 적용

### DIFF
--- a/src/main/java/org/mapledpmlab/type/skill/attackskill/soulmaster/SolunarSlash.java
+++ b/src/main/java/org/mapledpmlab/type/skill/attackskill/soulmaster/SolunarSlash.java
@@ -11,5 +11,6 @@ public class SolunarSlash extends AttackSkill {
         this.addFinalDamage(0.9);       // 마스터 오브 더 소드
         this.addFinalDamage(2.2);       // 코어강화
         this.addIgnoreDefenseList(20L);
+        this.setCooldown(5.0);
     }
 }


### PR DESCRIPTION
솔루나 슬래시 쿨타임 미적용으로 dpm이 높게 측정된것같습니다.